### PR TITLE
Use global position arrays in OLPR dump

### DIFF
--- a/openmx.c
+++ b/openmx.c
@@ -667,10 +667,15 @@ int main(int argc, char *argv[])
 
         /* 2) 生成 <r> */
         extern double ****OLPpox, ****OLPpoy, ****OLPpoz;
+        extern double ****OLPpox_all, ****OLPpoy_all, ****OLPpoz_all;
         Calc_OLP_r(1, myid);
 
         /* 3) 只写 S 和 r */
-        Dump_OverlapOnly_SCFOUT("openmx_olpr.scfout", OLP, OLPpox, OLPpoy, OLPpoz);
+        Dump_OverlapOnly_SCFOUT("openmx_olpr.scfout",
+                                OLP,
+                                OLPpox_all,
+                                OLPpoy_all,
+                                OLPpoz_all);
 
         if (myid==Host_ID) printf("[OLPR] dump done, exiting\n");
       #ifdef MPI


### PR DESCRIPTION
## Summary
- Declare global OLPpox_all/poy_all/poz_all arrays in `openmx.c`
- Dump overlap and position matrices using global arrays when OLPR_DUMP is enabled

## Testing
- `make openmx -j4` *(fails: mpiicc not found)*
- `./openmx run.dat` *(fails: executable not built)*

------
https://chatgpt.com/codex/tasks/task_e_689d2ab28f0c8324ac42bfb5f7a71949