### PR TITLE
Fix orientation of r matrices in overlap-only dump

### DIFF
--- a/OverlapOnlyDump.c
+++ b/OverlapOnlyDump.c
@@ -81,7 +81,8 @@ static void dump_block_matrix_r(FILE *fp,
   double ****ARR = (dir==0?RX:(dir==1?RY:RZ));
   for (int ii=0; ii<tno_center; ++ii) {
     for (int jj=0; jj<tno_neigh;  ++jj) {
-      double v = ARR[ct_AN][h_AN][ii][jj];
+      /* rows = neighbour, columns = centre (Julia reader expectation) */
+      double v = ARR[ct_AN][h_AN][jj][ii];
       fwrite(&v, sizeof(double), 1, fp);
     }
   }


### PR DESCRIPTION
## Summary
- Correct orientation of position matrix blocks in `dump_block_matrix_r` so rows correspond to neighbours and columns to centres

## Testing
- `gcc -c OverlapOnlyDump.c -I.` *(fails: mpi.h: No such file or directory)*
- `gcc test_dump_r.c -o test_dump_r && ./test_dump_r`


------
https://chatgpt.com/codex/tasks/task_e_689d2ab3b3a88324a4991c866a65494d