### PR TITLE
Call Set_Orbitals_Grid before overlap-position dump

### DIFF
--- a/openmx.c
+++ b/openmx.c
@@ -668,6 +668,7 @@ int main(int argc, char *argv[])
         /* 2) 生成 <r> */
         extern double ****OLPpox, ****OLPpoy, ****OLPpoz;
         extern double ****OLPpox_all, ****OLPpoy_all, ****OLPpoz_all;
+        Set_Orbitals_Grid(0);           /* populate Orbs_Grid / Orbs_Grid_FNAN */
         Calc_OLP_r(1, myid);
 
         /* 3) 只写 S 和 r */


### PR DESCRIPTION
## Summary
- Populate orbital grids before calculating position-dependent overlap for OLPR_DUMP mode.

## Testing
- `make openmx` *(fails: mpiicc missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d394e31a083248781b947bf19a1cd