### PR TITLE
Fix print_like_openmx Rn index output

### DIFF
--- a/example/print_like_openmx.jl
+++ b/example/print_like_openmx.jl
@@ -118,7 +118,7 @@ function print_like_openmx(data; printS=false, printRx=false, printRy=false, pri
                 rn_idx, (ri,rj,rk) = rn_index_and_triplet(atv_ijk, ncn[i][h])
                 # 有些 OpenMX 变体会把 Rn 打成四元（0 i j k），这里两种都给：先三元，再整数
                 @printf("global index=%d  local index=%d (global=%d, Rn=%d %d %d %d)\n",
-                        i, h-1, i, 0, ri, rj, rk)
+                        i, h-1, i, rn_idx, ri, rj, rk)
                 M = OLP_r[dir][i][h]
                 for r in 1:size(M,1); print_row(M[r, :]); end
             end


### PR DESCRIPTION
## Summary
- Use computed `rn_idx` when printing Rn for position-operator overlap matrices in `print_like_openmx.jl`

## Testing
- ⚠️ `julia -q example/print_like_openmx.jl example/openmx_olpr.scfout` *(Julia not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e2eb64034832482e085f285607758