### PR TITLE
Transpose dump_block_matrix_r to match expected orientation

### DIFF
--- a/OverlapOnlyDump.c
+++ b/OverlapOnlyDump.c
@@ -68,8 +68,10 @@ static void dump_block_matrix_r(FILE *fp,
   double ****ARR = (dir==0?RX:(dir==1?RY:RZ));
   for (int ii=0; ii<tno_center; ++ii) {
     for (int jj=0; jj<tno_neigh;  ++jj) {
-      /* rows = neighbour, columns = centre (Julia reader expectation) */
-      double v = ARR[ct_AN][h_AN][jj][ii];
+      /* rows = neighbour, columns = centre (Julia reader expectation)
+         The matrix element order in OpenMX is (centre, neighbour),
+         so transpose here to match the expected orientation. */
+      double v = ARR[ct_AN][h_AN][ii][jj];
       fwrite(&v, sizeof(double), 1, fp);
     }
   }


### PR DESCRIPTION
## Summary
- fix incorrect index order in `dump_block_matrix_r` so neighbor and center indices are not swapped

## Testing
- `make -j2` *(fails: mpiicc: No such file or directory)*
- `mpirun -np 2 ./openmx example/mos2/openmx_in.dat` *(fails: command not found: mpirun)*

------
https://chatgpt.com/codex/tasks/task_e_68a21de53d4483248d56c9fb8e9526f4