### PR TITLE
Fix index ordering for OpenMX-style overlap printing

### DIFF
--- a/example/cu/print_like_openmx.jl
+++ b/example/cu/print_like_openmx.jl
@@ -100,7 +100,7 @@ function print_like_openmx(data; printS=false, printRx=false, printRy=false, pri
                 rn_idx, (ri,rj,rk) = rn_index_and_triplet(atv_ijk, ncn[i][h])
                 # local index 从 0 开始更贴近 OpenMX 输出
                 @printf("global index=%d  local index=%d (global=%d, Rn=%d)\n",
-                        B, h-1, i, rn_idx)
+                        i, h-1, B, rn_idx)
                 M = OLP[i][h]
                 for r in 1:size(M,1); print_row(M[r, :]); end
             end
@@ -116,7 +116,7 @@ function print_like_openmx(data; printS=false, printRx=false, printRy=false, pri
                 rn_idx, (ri,rj,rk) = rn_index_and_triplet(atv_ijk, ncn[i][h])
                 # 有些 OpenMX 变体会把 Rn 打成四元（0 i j k），这里两种都给：先三元，再整数
                 @printf("global index=%d  local index=%d (global=%d, Rn=%d %d %d %d)\n",
-                        B, h-1, i, rn_idx, ri, rj, rk)
+                        i, h-1, B, rn_idx, ri, rj, rk)
                 M = OLP_r[dir][i][h]
                 for r in 1:size(M,1); print_row(M[r, :]); end
             end

--- a/example/print_like_openmx.jl
+++ b/example/print_like_openmx.jl
@@ -100,7 +100,7 @@ function print_like_openmx(data; printS=false, printRx=false, printRy=false, pri
                 rn_idx, (ri,rj,rk) = rn_index_and_triplet(atv_ijk, ncn[i][h])
                 # local index 从 0 开始更贴近 OpenMX 输出
                 @printf("global index=%d  local index=%d (global=%d, Rn=%d)\n",
-                        B, h-1, i, rn_idx)
+                        i, h-1, B, rn_idx)
                 M = OLP[i][h]
                 for r in 1:size(M,1); print_row(M[r, :]); end
             end
@@ -116,7 +116,7 @@ function print_like_openmx(data; printS=false, printRx=false, printRy=false, pri
                 rn_idx, (ri,rj,rk) = rn_index_and_triplet(atv_ijk, ncn[i][h])
                 # 有些 OpenMX 变体会把 Rn 打成四元（0 i j k），这里两种都给：先三元，再整数
                 @printf("global index=%d  local index=%d (global=%d, Rn=%d %d %d %d)\n",
-                        B, h-1, i, rn_idx, ri, rj, rk)
+                        i, h-1, B, rn_idx, ri, rj, rk)
                 M = OLP_r[dir][i][h]
                 for r in 1:size(M,1); print_row(M[r, :]); end
             end


### PR DESCRIPTION
## Summary
- ensure global index reflects center atom in overlap and position matrices
- keep neighbor index in parentheses for both CPU and CUDA examples

## Testing
- `julia example/print_like_openmx.jl example/openmx_olpr.scfout --S` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a234fbc2048324bffe207130eb3765